### PR TITLE
RoundService implementation

### DIFF
--- a/service/delayed_error.go
+++ b/service/delayed_error.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"sync"
 	"time"
 )
 
@@ -31,4 +32,39 @@ func (des *DelayedErrorService) Start() (errChan chan error, err error) {
 
 func (des *DelayedErrorService) Stop() (err error) {
 	return des.base.Stop()
+}
+
+type BlockingDelayedErrorService struct {
+	sleepDuration time.Duration
+	stopChan      chan interface{}
+	wg            sync.WaitGroup
+}
+
+func NewBlockingDelayedErrorService(d time.Duration) *BlockingDelayedErrorService {
+	return &BlockingDelayedErrorService{
+		sleepDuration: d,
+		stopChan:      make(chan interface{}),
+	}
+}
+func (bdss *BlockingDelayedErrorService) Start() (err error) {
+	bdss.wg.Add(1)
+	defer bdss.wg.Done()
+	timer := time.NewTimer(bdss.sleepDuration)
+	select {
+	case <-timer.C:
+		return ErrDelayedErrorServiceCritical
+	case <-bdss.stopChan:
+		timer.Stop()
+		return fmt.Errorf("early exit")
+	}
+}
+
+func (bdss *BlockingDelayedErrorService) Stop() (err error) {
+	if bdss.stopChan == nil {
+		return ErrBaseServiceAlreadyStopped
+	}
+	close(bdss.stopChan)
+	bdss.stopChan = nil
+	bdss.wg.Wait()
+	return
 }

--- a/service/delayed_error.go
+++ b/service/delayed_error.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"fmt"
-	"log"
 	"time"
 )
 
@@ -10,32 +9,26 @@ var ErrDelayedErrorServiceCritical = fmt.Errorf("DelayedErrorService critical er
 
 // StartErrorService will error out on Start after a given duration
 type DelayedErrorService struct {
+	base          BaseService
 	sleepDuration time.Duration
-	errChan       chan error
 }
 
 func NewDelayedErrorService(duration time.Duration) *DelayedErrorService {
 	return &DelayedErrorService{
+		base:          *NewBaseService(),
 		sleepDuration: duration,
-		errChan:       make(chan error),
 	}
 }
 
 func (des *DelayedErrorService) Start() (errChan chan error, err error) {
 	go func() {
 		time.Sleep(des.sleepDuration)
-		errChan <- ErrDelayedErrorServiceCritical
+		des.base.ErrChan <- ErrDelayedErrorServiceCritical
 		des.Stop()
 	}()
-	return des.errChan, nil
+	return des.base.ErrChan, nil
 }
 
 func (des *DelayedErrorService) Stop() (err error) {
-	if des.errChan == nil {
-		return fmt.Errorf("DelayedErrorService already stopped")
-	}
-	log.Println("DelayedErrorService stopped")
-	close(des.errChan)
-	des.errChan = nil
-	return nil
+	return des.base.Stop()
 }

--- a/service/delayed_stop.go
+++ b/service/delayed_stop.go
@@ -1,7 +1,9 @@
 package service
 
 import (
+	"fmt"
 	"log"
+	"sync"
 	"time"
 )
 
@@ -30,4 +32,39 @@ func (des *DelayedStopService) Start() (errChan chan error, err error) {
 
 func (des *DelayedStopService) Stop() (err error) {
 	return des.base.Stop()
+}
+
+type BlockingDelayedStopService struct {
+	sleepDuration time.Duration
+	stopChan      chan interface{}
+	wg            sync.WaitGroup
+}
+
+func NewBlockingDelayedStopService(d time.Duration) *BlockingDelayedStopService {
+	return &BlockingDelayedStopService{
+		sleepDuration: d,
+		stopChan:      make(chan interface{}),
+	}
+}
+func (bdss *BlockingDelayedStopService) Start() (err error) {
+	bdss.wg.Add(1)
+	defer bdss.wg.Done()
+	timer := time.NewTimer(bdss.sleepDuration)
+	select {
+	case <-timer.C:
+	case <-bdss.stopChan:
+		timer.Stop()
+		return fmt.Errorf("early exit")
+	}
+	return nil
+}
+
+func (bdss *BlockingDelayedStopService) Stop() (err error) {
+	if bdss.stopChan == nil {
+		return ErrBaseServiceAlreadyStopped
+	}
+	close(bdss.stopChan)
+	bdss.stopChan = nil
+	bdss.wg.Wait()
+	return
 }

--- a/service/delayed_stop.go
+++ b/service/delayed_stop.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+	"log"
+	"time"
+)
+
+type DelayedStopService struct {
+	base          BaseService
+	sleepDuration time.Duration
+}
+
+func NewDelayedStopService(duration time.Duration) *DelayedStopService {
+	return &DelayedStopService{
+		base:          *NewBaseService(),
+		sleepDuration: duration,
+	}
+}
+
+func (des *DelayedStopService) Start() (errChan chan error, err error) {
+	go func() {
+		time.Sleep(des.sleepDuration)
+		err := des.Stop()
+		if err != nil {
+			log.Printf("%v", err)
+		}
+	}()
+	return des.base.ErrChan, nil
+}
+
+func (des *DelayedStopService) Stop() (err error) {
+	return des.base.Stop()
+}

--- a/service/service.go
+++ b/service/service.go
@@ -13,6 +13,15 @@ type Service interface {
 	Stop() (err error)
 }
 
+type BlockingService interface {
+	// Start is a blocking function that will return an error in a fatal error, or nil on
+	// successful completion
+	Start() (err error)
+	// Stop will shutdown the BlockingService.  Packages that implement the SubService interface should implement a timeout to ensure Stop()
+	// does not block indefinitely. Will unblock the caller of Start()
+	Stop() (err error)
+}
+
 var ErrBaseServiceAlreadyStopped = fmt.Errorf("already stopped")
 
 type BaseService struct {

--- a/service/service.go
+++ b/service/service.go
@@ -1,5 +1,7 @@
 package service
 
+import "fmt"
+
 // Service is a generalized interface for a long running asynchronous service
 type Service interface {
 	// Start returns an error channel that is only written to if err == nil.  It is implied that
@@ -11,13 +13,27 @@ type Service interface {
 	Stop() (err error)
 }
 
+var ErrBaseServiceAlreadyStopped = fmt.Errorf("already stopped")
+
 type BaseService struct {
-	ErrorChan chan error
+	ErrChan chan error
+}
+
+func NewBaseService() *BaseService {
+	return &BaseService{
+		ErrChan: make(chan error),
+	}
 }
 
 func (bs *BaseService) Start() (errChan chan error, err error) {
-	return
+	return bs.ErrChan, nil
 }
+
 func (bs *BaseService) Stop() error {
+	if bs.ErrChan == nil {
+		return ErrBaseServiceAlreadyStopped
+	}
+	close(bs.ErrChan)
+	bs.ErrChan = nil
 	return nil
 }

--- a/service/service_round.go
+++ b/service/service_round.go
@@ -52,7 +52,7 @@ func (rs *RoundService) handleErrChans(errChan chan error, errChanA chan error, 
 				errChanA = nil
 			}
 			if err != nil {
-				errChan <- fmt.Errorf("error from serviceA: %w, stopping ServiceRound", err)
+				errChan <- fmt.Errorf("error from serviceA: %w, stopping RoundService", err)
 				err := rs.Stop()
 				if err != nil {
 					log.Printf("error stopping RoundService: %v\n", err)
@@ -63,7 +63,7 @@ func (rs *RoundService) handleErrChans(errChan chan error, errChanA chan error, 
 				errChanB = nil
 			}
 			if err != nil {
-				errChan <- fmt.Errorf("error from serviceB: %w, stopping ServiceRound", err)
+				errChan <- fmt.Errorf("error from serviceB: %w, stopping RoundService", err)
 				err := rs.Stop()
 				if err != nil {
 					log.Printf("error stopping RoundService: %v\n", err)
@@ -79,7 +79,7 @@ func (rs *RoundService) handleErrChans(errChan chan error, errChanA chan error, 
 func (sr *RoundService) Start() (errChan chan error, err error) {
 	errChanA, errChanB, err := sr.newRound(errChan)
 	if err != nil {
-		return nil, err
+		return
 	}
 
 	sr.wg.Add(1)
@@ -97,7 +97,7 @@ func (sr *RoundService) Start() (errChan chan error, err error) {
 			default:
 				errChanA, errChanB, err := sr.newRound(errChan)
 				if err != nil {
-					errChan <- fmt.Errorf("error calling newRound: %w", err)
+					errChan <- fmt.Errorf("error calling newRound: %w, stopping RoundService", err)
 					err := sr.Stop()
 					if err != nil {
 						log.Printf("error stopping RoundService: %v\n", err)
@@ -109,8 +109,7 @@ func (sr *RoundService) Start() (errChan chan error, err error) {
 
 		}
 	}()
-
-	return errChan, nil
+	return
 }
 
 func (sr *RoundService) Stop() (err error) {
@@ -134,10 +133,8 @@ func (sr *RoundService) Stop() (err error) {
 
 	if errs[0] != nil && !errors.Is(errs[0], ErrBaseServiceAlreadyStopped) {
 		err = errs[0]
-		return
 	} else if errs[1] != nil && !errors.Is(errs[1], ErrBaseServiceAlreadyStopped) {
 		err = errs[1]
-		return
 	}
 	return
 }

--- a/service/service_round.go
+++ b/service/service_round.go
@@ -1,0 +1,143 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"sync"
+)
+
+type RoundService struct {
+	serviceA    Service
+	serviceB    Service
+	newServices func() (serviceA Service, serviceB Service)
+	stopChan    chan interface{}
+	wg          sync.WaitGroup
+}
+
+func NewRoundService(newServices func() (serviceA Service, serviceB Service)) (sr *RoundService) {
+	return &RoundService{
+		newServices: newServices,
+		stopChan:    make(chan interface{}),
+	}
+}
+
+func (rs *RoundService) newRound(errChan chan error) (errChanA, errChanB chan error, err error) {
+	serviceA, serviceB := rs.newServices()
+
+	errChanA, err = serviceA.Start()
+	if err != nil {
+		return
+	}
+
+	errChanB, err = serviceB.Start()
+	if err != nil {
+		stopErr := serviceA.Stop()
+		if stopErr != nil {
+			log.Printf("error stopping serviceA: %v", stopErr)
+		}
+		return
+	}
+
+	rs.serviceA = serviceA
+	rs.serviceB = serviceB
+	return
+}
+
+func (rs *RoundService) handleErrChans(errChan chan error, errChanA chan error, errChanB chan error) {
+	for {
+		select {
+		case err, ok := <-errChanA:
+			if !ok {
+				errChanA = nil
+			}
+			if err != nil {
+				errChan <- fmt.Errorf("error from serviceA: %w, stopping ServiceRound", err)
+				err := rs.Stop()
+				if err != nil {
+					log.Printf("error stopping RoundService: %v\n", err)
+				}
+			}
+		case err, ok := <-errChanB:
+			if !ok {
+				errChanB = nil
+			}
+			if err != nil {
+				errChan <- fmt.Errorf("error from serviceB: %w, stopping ServiceRound", err)
+				err := rs.Stop()
+				if err != nil {
+					log.Printf("error stopping RoundService: %v\n", err)
+				}
+			}
+		}
+		if errChanA == nil && errChanB == nil {
+			break
+		}
+	}
+}
+
+func (sr *RoundService) Start() (errChan chan error, err error) {
+	errChanA, errChanB, err := sr.newRound(errChan)
+	if err != nil {
+		return nil, err
+	}
+
+	sr.wg.Add(1)
+	errChan = make(chan error)
+	go func() {
+		defer sr.wg.Done()
+		defer close(errChan)
+		// 1st round
+		sr.handleErrChans(errChan, errChanA, errChanB)
+		// subsequent rounds
+		for {
+			select {
+			case <-sr.stopChan:
+				return
+			default:
+				errChanA, errChanB, err := sr.newRound(errChan)
+				if err != nil {
+					errChan <- fmt.Errorf("error calling newRound: %w", err)
+					err := sr.Stop()
+					if err != nil {
+						log.Printf("error stopping RoundService: %v\n", err)
+					}
+					return
+				}
+				sr.handleErrChans(errChan, errChanA, errChanB)
+			}
+
+		}
+	}()
+
+	return errChan, nil
+}
+
+func (sr *RoundService) Stop() (err error) {
+	close(sr.stopChan)
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	errs := [2]error{}
+	go func() {
+		defer wg.Done()
+		errs[0] = sr.serviceA.Stop()
+	}()
+	go func() {
+		defer wg.Done()
+		errs[1] = sr.serviceB.Stop()
+	}()
+
+	wg.Wait()
+	sr.wg.Wait()
+
+	if errs[0] != nil && !errors.Is(errs[0], ErrBaseServiceAlreadyStopped) {
+		err = errs[0]
+		return
+	} else if errs[1] != nil && !errors.Is(errs[1], ErrBaseServiceAlreadyStopped) {
+		err = errs[1]
+		return
+	}
+	return
+}

--- a/service/service_round.go
+++ b/service/service_round.go
@@ -125,7 +125,7 @@ func (rs *RoundService) Start() (errChan chan error, err error) {
 
 func (rs *RoundService) Stop() (err error) {
 	if rs.closed {
-		return ErrRoundServiceAlreadyStopped
+		return ErrBaseServiceAlreadyStopped
 	}
 	rs.closed = true
 	close(rs.stopChan)

--- a/service/service_round_test.go
+++ b/service/service_round_test.go
@@ -59,7 +59,7 @@ func TestRoundServiceMultipleClose(t *testing.T) {
 		}
 		err = sr.Stop()
 		if err != nil {
-			assert.ErrorIs(t, err, ErrBaseServiceAlreadyStopped)
+			assert.ErrorIs(t, err, ErrRoundServiceAlreadyStopped)
 		} else {
 			t.Errorf("expected error")
 		}

--- a/service/service_round_test.go
+++ b/service/service_round_test.go
@@ -22,7 +22,7 @@ func TestRoundServiceHappyPath(t *testing.T) {
 	done := make(chan interface{})
 	go func() {
 		defer close(done)
-		time.Sleep(5 * time.Second)
+		time.Sleep(3 * time.Second)
 		err := sr.Stop()
 		if err != nil {
 			t.Errorf("ServiceRound.Stop() error: %v", err)
@@ -35,6 +35,75 @@ func TestRoundServiceHappyPath(t *testing.T) {
 		}
 	}
 	<-done
+}
+
+func TestRoundServiceMultipleClose(t *testing.T) {
+	sr := NewRoundService(
+		func() (serviceA Service, serviceB Service) {
+			return NewDelayedStopService(1 * time.Second),
+				NewDelayedStopService(1 * time.Second)
+		},
+	)
+	errChan, err := sr.Start()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	done := make(chan interface{})
+	go func() {
+		defer close(done)
+		time.Sleep(3 * time.Second)
+		err := sr.Stop()
+		if err != nil {
+			t.Errorf("ServiceRound.Stop() error: %v", err)
+		}
+		err = sr.Stop()
+		if err != nil {
+			assert.ErrorIs(t, err, ErrBaseServiceAlreadyStopped)
+		} else {
+			t.Errorf("expected error")
+		}
+	}()
+
+	for err := range errChan {
+		if err != nil {
+			t.Errorf("ServiceRound error: %v", err)
+		}
+	}
+	<-done
+}
+
+func TestRoundServiceDelayedError(t *testing.T) {
+	sr := NewRoundService(
+		func() (serviceA Service, serviceB Service) {
+			return NewDelayedStopService(2 * time.Second),
+				NewDelayedErrorService(1 * time.Second)
+		},
+	)
+
+	errChan, err := sr.Start()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	for err := range errChan {
+		assert.ErrorIs(t, err, ErrDelayedErrorServiceCritical)
+	}
+
+	sr = NewRoundService(
+		func() (serviceA Service, serviceB Service) {
+			return NewDelayedErrorService(1 * time.Second),
+				NewDelayedStopService(2 * time.Second)
+		},
+	)
+	errChan, err = sr.Start()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	for err := range errChan {
+		assert.ErrorIs(t, err, ErrDelayedErrorServiceCritical)
+	}
 }
 
 func TestRoundServiceStartError(t *testing.T) {
@@ -55,4 +124,29 @@ func TestRoundServiceStartError(t *testing.T) {
 	)
 	_, err = sr.Start()
 	assert.ErrorIs(t, err, ErrStartErrorService)
+}
+
+func TestRoundServiceNewRoundError(t *testing.T) {
+	newRoundCallCount := 0
+	sr := NewRoundService(
+		func() (serviceA Service, serviceB Service) {
+			newRoundCallCount++
+			switch newRoundCallCount {
+			case 1:
+				return NewDelayedStopService(1 * time.Second),
+					NewDelayedStopService(1 * time.Second)
+			default:
+				return NewDelayedStopService(1 * time.Second),
+					NewStartErrorService(100 * time.Millisecond)
+			}
+		},
+	)
+	errChan, err := sr.Start()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	for err := range errChan {
+		assert.ErrorIs(t, err, ErrStartErrorService)
+	}
 }

--- a/service/service_round_test.go
+++ b/service/service_round_test.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRoundServiceHappyPath(t *testing.T) {
+	sr := NewRoundService(
+		func() (serviceA Service, serviceB Service) {
+			return NewDelayedStopService(1 * time.Second),
+				NewDelayedStopService(1 * time.Second)
+		},
+	)
+	errChan, err := sr.Start()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	done := make(chan interface{})
+	go func() {
+		defer close(done)
+		time.Sleep(5 * time.Second)
+		err := sr.Stop()
+		if err != nil {
+			t.Errorf("ServiceRound.Stop() error: %v", err)
+		}
+	}()
+
+	for err := range errChan {
+		if err != nil {
+			t.Errorf("ServiceRound error: %v", err)
+		}
+	}
+	<-done
+}
+
+func TestRoundServiceStartError(t *testing.T) {
+	sr := NewRoundService(
+		func() (serviceA Service, serviceB Service) {
+			return NewStartErrorService(1 * time.Second),
+				NewDelayedStopService(1 * time.Second)
+		},
+	)
+	_, err := sr.Start()
+	assert.ErrorIs(t, err, ErrStartErrorService)
+
+	sr = NewRoundService(
+		func() (serviceA Service, serviceB Service) {
+			return NewDelayedStopService(1 * time.Second),
+				NewStartErrorService(1 * time.Second)
+		},
+	)
+	_, err = sr.Start()
+	assert.ErrorIs(t, err, ErrStartErrorService)
+}

--- a/service/start_error.go
+++ b/service/start_error.go
@@ -9,11 +9,13 @@ var ErrStartErrorService = fmt.Errorf("FATAL: StartErrorService fatal error")
 
 // StartErrorService will error out on Start after a given duration
 type StartErrorService struct {
+	BaseService
 	sleepDuration time.Duration
 }
 
 func NewStartErrorService(duration time.Duration) *StartErrorService {
 	return &StartErrorService{
+		BaseService:   *NewBaseService(),
 		sleepDuration: duration,
 	}
 }
@@ -24,5 +26,5 @@ func (ses *StartErrorService) Start() (errChan chan error, err error) {
 }
 
 func (ses *StartErrorService) Stop() (err error) {
-	return fmt.Errorf("huh? shouldn't be called")
+	return ses.BaseService.Stop()
 }

--- a/service/start_error.go
+++ b/service/start_error.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+var ErrStartErrorService = fmt.Errorf("FATAL: StartErrorService fatal error")
+
 // StartErrorService will error out on Start after a given duration
 type StartErrorService struct {
 	sleepDuration time.Duration
@@ -18,7 +20,7 @@ func NewStartErrorService(duration time.Duration) *StartErrorService {
 
 func (ses *StartErrorService) Start() (errChan chan error, err error) {
 	time.Sleep(ses.sleepDuration)
-	return nil, fmt.Errorf("FATAL: StartErrorService fatal error")
+	return nil, ErrStartErrorService
 }
 
 func (ses *StartErrorService) Stop() (err error) {

--- a/service/sub_service_round.go
+++ b/service/sub_service_round.go
@@ -1,0 +1,121 @@
+package service
+
+import (
+	"errors"
+	"sync"
+)
+
+var ErrSubServiceRoundAlreadyStopped = ErrBaseServiceAlreadyStopped
+
+type BlockingServiceRound struct {
+	serviceA    BlockingService
+	serviceB    BlockingService
+	newServices func() (serviceA BlockingService, serviceB BlockingService)
+	stopChan    chan interface{}
+	wg          sync.WaitGroup
+	closed      bool
+}
+
+func NewBlockingServiceRound(newServices func() (serviceA BlockingService, serviceB BlockingService)) (sr *BlockingServiceRound) {
+	return &BlockingServiceRound{
+		newServices: newServices,
+		stopChan:    make(chan interface{}),
+	}
+}
+
+func (rs *BlockingServiceRound) Start() (errChan chan error, err error) {
+	errChan = make(chan error)
+
+	rs.wg.Add(1)
+
+	go func() {
+		defer close(errChan)
+		defer rs.wg.Done()
+
+	round:
+		for {
+			serviceA, serviceB := rs.newServices()
+
+			rs.serviceA = serviceA
+			rs.serviceB = serviceB
+
+			errsA := make(chan error)
+			errsB := make(chan error)
+			go func() {
+				defer close(errsA)
+				err := serviceA.Start()
+				if err != nil {
+					errsA <- err
+				}
+			}()
+			go func() {
+				defer close(errsB)
+				err := serviceB.Start()
+				if err != nil {
+					errsB <- err
+				}
+			}()
+
+		poll:
+			for {
+				select {
+				case <-rs.stopChan:
+					break round
+				case err, ok := <-errsA:
+					if !ok {
+						errsA = nil
+					}
+					if err != nil {
+						errChan <- err
+						go rs.Stop()
+					}
+				case err, ok := <-errsB:
+					if !ok {
+						errsB = nil
+					}
+					if err != nil {
+						errChan <- err
+						go rs.Stop()
+					}
+				default:
+					if errsA == nil && errsB == nil {
+						break poll
+					}
+				}
+			}
+		}
+	}()
+
+	return
+}
+
+func (rs *BlockingServiceRound) Stop() (err error) {
+	if rs.closed {
+		return ErrBaseServiceAlreadyStopped
+	}
+	rs.closed = true
+	close(rs.stopChan)
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	errs := [2]error{}
+	go func() {
+		defer wg.Done()
+		errs[0] = rs.serviceA.Stop()
+	}()
+	go func() {
+		defer wg.Done()
+		errs[1] = rs.serviceB.Stop()
+	}()
+
+	wg.Wait()
+	rs.wg.Wait()
+
+	if errs[0] != nil && !errors.Is(errs[0], ErrBaseServiceAlreadyStopped) {
+		err = errs[0]
+	} else if errs[1] != nil && !errors.Is(errs[1], ErrBaseServiceAlreadyStopped) {
+		err = errs[1]
+	}
+	return
+}

--- a/service/sub_service_round_test.go
+++ b/service/sub_service_round_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -52,4 +53,44 @@ func TestBlockingServiceRoundStopOnError(t *testing.T) {
 	for err := range errChan {
 		assert.ErrorIs(t, err, ErrDelayedErrorServiceCritical)
 	}
+}
+
+func TestBlockingServiceRoundStopBeforeNextRound(t *testing.T) {
+	sr := NewBlockingServiceRound(
+		func() (serviceA BlockingService, serviceB BlockingService) {
+			return NewBlockingDelayedStopService(1 * time.Second),
+				NewBlockingDelayedStopService(1 * time.Second)
+		},
+	)
+
+	wg := sync.WaitGroup{}
+
+	wg.Add(1)
+	sr.roundDone = func() {
+		go func() {
+			defer wg.Done()
+			err := sr.Stop()
+			if err != nil {
+				t.Errorf("%v", err)
+			}
+		}()
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	errChan, err := sr.Start()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for err := range errChan {
+			if err != nil {
+				t.Errorf("ServiceRound error: %v", err)
+			}
+		}
+	}()
+
+	wg.Wait()
 }

--- a/service/sub_service_round_test.go
+++ b/service/sub_service_round_test.go
@@ -1,0 +1,55 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBlockingServiceRoundHappyPath(t *testing.T) {
+	sr := NewBlockingServiceRound(
+		func() (serviceA BlockingService, serviceB BlockingService) {
+			return NewBlockingDelayedStopService(1 * time.Second),
+				NewBlockingDelayedStopService(1 * time.Second)
+		},
+	)
+	errChan, err := sr.Start()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	done := make(chan interface{})
+	go func() {
+		time.Sleep(5 * time.Second)
+		err := sr.Stop()
+		if err != nil {
+			t.Errorf("yo")
+		}
+		close(done)
+	}()
+
+	for err := range errChan {
+		if err != nil {
+			t.Errorf("ServiceRound error: %v", err)
+		}
+	}
+	<-done
+}
+
+func TestBlockingServiceRoundStopOnError(t *testing.T) {
+	sr := NewBlockingServiceRound(
+		func() (serviceA BlockingService, serviceB BlockingService) {
+			return NewBlockingDelayedStopService(2 * time.Second),
+				NewBlockingDelayedErrorService(1 * time.Second)
+		},
+	)
+	errChan, err := sr.Start()
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+
+	for err := range errChan {
+		assert.ErrorIs(t, err, ErrDelayedErrorServiceCritical)
+	}
+}


### PR DESCRIPTION
Implementation of `RoundService` which managers two `Service` implementations which are expected to stop at some point without error.  Once both services are stopped, new instances of each service are instantiated again which makes up a round.  If either service errors when calling `Start` or we receive an error from any of the error channels, both services should be stopped, an an error should be propagated back through the error chan provided by `RoundService`.
